### PR TITLE
Bugfix for enter keypress in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,14 +26,14 @@ function prompt (message, hideInput, cb) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
-      else if (key.name === 'enter') {
+      else if (key.name === 'return') {
         process.stdin.removeListener('keypress', listen);
         process.stdin.pause();
         if (hideInput) {
           setRawMode(false);
           console.log();
         }
-        cb(line, function () {}); // for backwards-compatibility, fake end() callback
+        cb(line.trim(), function () {}); // for backwards-compatibility, fake end() callback
         return;
       }
       if (key.name === 'backspace') line = line.slice(0, -1);
@@ -97,8 +97,7 @@ function multi (questions, cb) {
     }
     else if (q.type === 'boolean') {
       label += '(y/n) ';
-      q.validate = function (val) {
-        val = val.trim();
+      q.validate = function (val){
         if (!val.match(/^(yes|ok|true|y|no|false|n)$/i)) return false;
       };
     }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function prompt (message, hideInput, cb) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
-      else if (key.name === 'return' || key.name === 'enter') {
+      else if (key.name === 'enter') {
         process.stdin.removeListener('keypress', listen);
         process.stdin.pause();
         if (hideInput) {
@@ -98,6 +98,7 @@ function multi (questions, cb) {
     else if (q.type === 'boolean') {
       label += '(y/n) ';
       q.validate = function (val) {
+        val = val.trim();
         if (!val.match(/^(yes|ok|true|y|no|false|n)$/i)) return false;
       };
     }


### PR DESCRIPTION
On my machine (fairly standard Windows 7 x64 HP laptop), the following
happens:

- [PROBLEM] Pressing the Enter key first fires a 'return' keypress event
immediately followed by an 'enter' keypress event. This meant that
chained prompts would get called back-to-back.

- [BUGFIX] Removed key.name === 'enter', now just checking checking on
key.name === 'return'.
- Reason for removing key.name === 'enter' (instead of 'return'), for
some reason, I couldn't get past password prompt with 'enter' and didn't
have this problem with 'return'. Maybe because return adds a newline
character?
- In 'boolean' check under multi, added 'val = val.trim()' because
'return' adds a newline character, and the regex would not match.
String.trim() removes the newline from the end of the string.
- [FYI] Haven't run the test cases