### PR TITLE
Attempt #2 for windows keypress bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,14 +26,14 @@ function prompt (message, hideInput, cb) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
-      else if (key.name === 'enter') {
+      else if (key.name === 'return') {
         process.stdin.removeListener('keypress', listen);
         process.stdin.pause();
         if (hideInput) {
           setRawMode(false);
           console.log();
         }
-        cb(line, function () {}); // for backwards-compatibility, fake end() callback
+        cb(line.trim(), function () {}); // for backwards-compatibility, fake end() callback
         return;
       }
       if (key.name === 'backspace') line = line.slice(0, -1);
@@ -97,8 +97,7 @@ function multi (questions, cb) {
     }
     else if (q.type === 'boolean') {
       label += '(y/n) ';
-      q.validate = function (val) {
-        val = val.trim();
+      q.validate = function (val){
         if (!val.match(/^(yes|ok|true|y|no|false|n)$/i)) return false;
       };
     }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function prompt (message, hideInput, cb) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
-      else if (key.name === 'return' || key.name === 'enter') {
+      else if (key.name === 'enter') {
         process.stdin.removeListener('keypress', listen);
         process.stdin.pause();
         if (hideInput) {
@@ -98,6 +98,7 @@ function multi (questions, cb) {
     else if (q.type === 'boolean') {
       label += '(y/n) ';
       q.validate = function (val) {
+        val = val.trim();
         if (!val.match(/^(yes|ok|true|y|no|false|n)$/i)) return false;
       };
     }


### PR DESCRIPTION
- Added key.name === 'enter' back to add support back for Unix/Mac (lines end in NL in these systems)
- Added a separate key.name === 'return', which was required for password because just using key.name === 'enter' sets the process rawMode to true, which broke password. This ONLY catches when hideInput == true.

Can you please test this on your system and see if it works? Crossing my fingers...