### PR TITLE
Handle end of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ prompt('enter your first name: ', function (val) {
   var first = val;
   prompt('and your last name: ', function (val) {
     console.log('hi, ' + first + ' ' + val + '!');
+  }, function (err) {
+    console.error('unable to read last name: ' + err);
   });
+}, function (err) {
+  console.error('unable to read first name: ' + err);
 });
 ```
 

--- a/examples/name.js
+++ b/examples/name.js
@@ -4,5 +4,9 @@ prompt('enter your first name: ', function (val) {
   var first = val;
   prompt('and your last name: ', function (val) {
     console.log('hi, ' + first + ' ' + val + '!');
+  }, function (err) {
+    console.error('unable to read last name: ' + err);
   });
+}, function (err) {
+  console.error('unable to read first name: ' + err);
 });

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 var tty = require('tty')
   , keypress = require('keypress')
+  , stdinEnded = false
 
-function prompt (message, hideInput, cb) {
+process.stdin.once('end', function() { stdinEnded = true; });
+
+function prompt (message, hideInput, onValue, onError) {
   if (typeof hideInput === 'function') {
-    cb = hideInput;
+    onError = onValue;
+    onValue = hideInput;
     hideInput = false;
   }
 
@@ -21,28 +25,45 @@ function prompt (message, hideInput, cb) {
 
   process.stdout.write(message);
 
+  var gotInput = false;
+
+  function done (err) {
+    process.stdin.removeListener('keypress', listen);
+    process.stdin.removeListener('error', done);
+    process.stdin.removeListener('end', done);
+    process.stdin.pause();
+    if (hideInput) {
+      setRawMode(false);
+      console.log();
+    }
+    if (err && onError) {
+      onError(err);
+    } else if (!gotInput && onError) {
+      onError(new Error('stdin has ended'));
+    } else {
+      onValue(line, function () {}); // for backwards-compatibility, fake end() callback
+    }
+  }
+
+  if (stdinEnded) {
+    process.nextTick(done);
+    return;
+  }
+
   function listen (c, key) {
+    gotInput = true;
     if (key) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
       else if (key.name === 'return'){
         if (hideInput == true){
-          process.stdin.removeListener('keypress', listen);
-          process.stdin.pause();
-          setRawMode(false);
-          console.log();
-          cb(line, function () {}); // for backwards-compatibility, fake end() callback
+          done();
         }
         return;
       } else if (key.name === 'enter' || key.sequence === '\r\n') {
-        process.stdin.removeListener('keypress', listen);
-        process.stdin.pause();
-        if (hideInput) {
-          setRawMode(false);
-          console.log();
-        }
-        cb(line.trim(), function () {}); // for backwards-compatibility, fake end() callback
+        line = line.trim();
+        done();
         return;
       }
       if (key.name === 'backspace') line = line.slice(0, -1);
@@ -51,20 +72,28 @@ function prompt (message, hideInput, cb) {
   }
 
   var line = '';
-  process.stdin.on('keypress', listen).resume();
+  process.stdin.on('keypress', listen)
+
+  if (onError) {
+    process.stdin
+      .once('error', done)
+      .once('end', done);
+  }
+
+  process.stdin.resume();
 }
 module.exports = prompt;
 
-function password (message, cb) {
+function password (message, onValue, onError) {
   prompt(message, true, function (val) {
     // password is required
-    if (!val.length) password(message, cb);
-    else cb(val, function () {}); // for backwards-compatibility, fake end() callback
-  });
+    if (!val) password(message, onValue, onError);
+    else onValue(val, function () {}); // for backwards-compatibility, fake end() callback
+  }, onError);
 }
 module.exports.password = password;
 
-function multi (questions, cb) {
+function multi (questions, onValue, onError) {
   var idx = 0, ret = {};
   (function ask () {
     var q = questions[idx++];
@@ -97,7 +126,7 @@ function multi (questions, cb) {
       else if (q.type === 'boolean') val = val.match(/^(yes|ok|true|y)$/i) ? true : false;
       if (typeof q.key !== 'undefined') ret[q.key] = val;
       if (questions[idx]) ask();
-      else cb(ret);
+      else onValue(ret);
     }
     var label = (q.label || q.key) + ': ';
     if (q.default) {
@@ -110,7 +139,7 @@ function multi (questions, cb) {
         if (!val.match(/^(yes|ok|true|y|no|false|n)$/i)) return false;
       };
     }
-    prompt(label, q.type === 'password', record);
+    prompt(label, q.type === 'password', record, onError);
   })();
 }
 module.exports.multi = multi;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "suppose": "~0.2.0"
+    "suppose": "~0.5.0"
   },
   "scripts": {
     "test": "make test"

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,4 +10,22 @@ describe('basic test', function () {
         done();
       });
   });
+
+  it('calls onError for premature end', function (done) {
+    var gotError = false;
+    suppose('node', [resolve(__dirname, '../examples/name.js')])
+      // Output to stderr is wrapped into an Error
+      .on('error', function (err) {
+        assert.strictEqual(
+            'unable to read first name: Error: stdin has ended\n',
+            err.message
+        );
+        gotError = true;
+      })
+      .end(function (code) {
+        assert(!code);
+        assert(gotError);
+        done();
+      });
+  });
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,10 +1,10 @@
 describe('basic test', function () {
   it('works', function (done) {
     suppose('node', [resolve(__dirname, '../examples/name.js')])
-      .on('enter your first name: ').respond('carliz\b\bos 8\n')
-      .on('and your last name: ').respond('rodriguez\n')
-      .on('hi, carlos 8 rodriguez!\n').respond("'sup!")
-      .error(assert.ifError)
+      .when('enter your first name: ').respond('carliz\b\bos 8\n')
+      .when('and your last name: ').respond('rodriguez\n')
+      .when('hi, carlos 8 rodriguez!\n').respond("'sup!")
+      .on('error', assert.ifError)
       .end(function (code) {
         assert(!code);
         done();

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,16 +1,19 @@
 describe('multi', function () {
   it('works', function (done) {
-    suppose('node', [resolve(__dirname, '../examples/multi.js')])
-      .debug(fs.createWriteStream('/tmp/debug.txt')) //optional writeable output stream
-      .on('username: (john_doe) ').respond('\n')
-      .on('password (must be at least 5 characters): ').respond('asdfff\b\b\n')
-      .on('password must be at least 5 characters long\npassword (must be at least 5 characters): ').respond('asdfff\n')
-      .on('number of pets: (6) ').respond('eight\n')
-      .on('number of pets: (6) ').respond('8\n')
-      .on('is this ok?: (y/n) ').respond('okay\n')
-      .on('is this ok?: (y/n) ').respond('yes\n')
-      .on("{ username: 'john_doe', password: 'asdfff', pets: 8 }\n").respond('great')
-      .error(assert.ifError)
+    var options = {
+      //optional writeable output stream
+      //debug: fs.createWriteStream('/tmp/debug.txt')
+    };
+    suppose('node', [resolve(__dirname, '../examples/multi.js')], options)
+      .when('username: (john_doe) ').respond('\n')
+      .when('password (must be at least 5 characters): ').respond('asdfff\b\b\n')
+      .when('password must be at least 5 characters long\npassword (must be at least 5 characters): ').respond('asdfff\n')
+      .when('number of pets: (6) ').respond('eight\n')
+      .when('number of pets: (6) ').respond('8\n')
+      .when('is this ok?: (y/n) ').respond('okay\n')
+      .when('is this ok?: (y/n) ').respond('yes\n')
+      .when("{ username: 'john_doe', password: 'asdfff', pets: 8 }\n").respond('great')
+      .on('error', assert.ifError)
       .end(function (code) {
         assert(!code);
         done();

--- a/test/password.js
+++ b/test/password.js
@@ -1,10 +1,13 @@
 describe('password', function () {
   it('works', function (done) {
-    suppose('node', [resolve(__dirname, '../examples/password.js')])
-      //.debug(fs.createWriteStream('/tmp/debug.txt')) //optional writeable output stream
-      .on('tell me a secret: ').respond('earthworn\bm jim\n')
-      .on('earthworm jim\n').respond('hey')
-      .error(assert.ifError)
+    var options = {
+      //optional writeable output stream
+      //debug: fs.createWriteStream('/tmp/debug.txt')
+    };
+    suppose('node', [resolve(__dirname, '../examples/password.js')], options)
+      .when('tell me a secret: ').respond('earthworn\bm jim\n')
+      .when('earthworm jim\n').respond('hey')
+      .on('error', assert.ifError)
       .end(function (code) {
         assert(!code);
         done();

--- a/test/windows.js
+++ b/test/windows.js
@@ -1,10 +1,10 @@
 describe('windows CRLF', function () {
   it('works', function (done) {
     suppose('node', [resolve(__dirname, '../examples/name.js')])
-      .on('enter your first name: ').respond('carlos\r\n')
-      .on('and your last name: ').respond('rodriguez\r\n')
-      .on('hi, carlos rodriguez!\n').respond("'sup!")
-      .error(assert.ifError)
+      .when('enter your first name: ').respond('carlos\r\n')
+      .when('and your last name: ').respond('rodriguez\r\n')
+      .when('hi, carlos rodriguez!\n').respond("'sup!")
+      .on('error', assert.ifError)
       .end(function (code) {
         assert(!code);
         done();


### PR DESCRIPTION
Currently prompt only listens for `'keypress'` events, which means that if the input ends (either by reaching the end of an input file or pipe, or the user sending EOF via `^D` at the terminal) prompt would never return.  This PR watches for `'end'` and `'error'` events which signal the end of input and handles it appropriately.  If any input has been received, it is returned.  If not, `null` is returned to differentiate it from the user sending empty input (i.e. just hitting Enter).

It also updates code, docs, and tests to handle returned `null` values:
- Update password and multi to recognize this value and cease reading.
- Add it to the name example so that users know to expect it.
- Add a test to check that the example behaves as expected.

Thanks for considering,
Kevin
